### PR TITLE
[config reload]Fixing config reload tests to handle failure error return

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -27,10 +27,14 @@ def config_system_checks_passed(duthost):
 
     logging.info("Checking if delayed services are up")
     out = duthost.shell("systemctl list-dependencies sonic-delayed.target --plain |sed '1d'")
-    for service in out['stdout'].splitlines():
-        out1 = duthost.shell("systemctl show {} --property=LastTriggerUSecMonotonic --value".format(service))
-        if out1['stdout'].strip() == "0":
-            return False
+    status = duthost.shell("systemctl is-enabled {}".format(out['stdout'].replace("\n", " ")))
+    services = [line.strip() for line in out['stdout'].splitlines()]
+    state = [line.strip() for line in status['stdout'].splitlines()]
+    for service in services:
+        if state[services.index(service)] == "enabled":
+            out1 = duthost.shell("systemctl show {} --property=LastTriggerUSecMonotonic --value".format(service))
+            if out1['stdout'].strip() == "0":
+                return False
     logging.info("All checks passed")
     return True
 

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -71,18 +71,19 @@ def test_reload_configuration_checks(duthosts, rand_one_dut_hostname, localhost,
 
     reboot(duthost, localhost, reboot_type="cold", wait=5)
     logging.info("Reload configuration check")
-    out = duthost.shell("sudo config reload -y", executable="/bin/bash")
+    out = duthost.shell("sudo config reload -y", executable="/bin/bash", module_ignore_errors=True)
     # config reload command shouldn't work immediately after system reboot
     assert "Retry later" in out['stdout']
+
     assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
 
     # After the system checks succeed the config reload command should not throw error
-    out = duthost.shell("sudo config reload -y", executable="/bin/bash")
+    out = duthost.shell("sudo config reload -y", executable="/bin/bash", module_ignore_errors=True)
     assert "Retry later" not in out['stdout']
 
     # Immediately after one config reload command, another shouldn't execute and wait for system checks
     logging.info("Checking config reload after system is up")
-    out = duthost.shell("sudo config reload -y", executable="/bin/bash")
+    out = duthost.shell("sudo config reload -y", executable="/bin/bash", module_ignore_errors=True)
     assert "Retry later" in out['stdout']
     assert wait_until(300, 20, 0, config_system_checks_passed, duthost)
 
@@ -90,7 +91,7 @@ def test_reload_configuration_checks(duthosts, rand_one_dut_hostname, localhost,
     duthost.shell("sudo service swss stop")
 
     # Without swss running config reload option should not proceed
-    out = duthost.shell("sudo config reload -y", executable="/bin/bash")
+    out = duthost.shell("sudo config reload -y", executable="/bin/bash", module_ignore_errors=True)
     assert "Retry later" in out['stdout']
 
     # However with force option config reload should proceed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fixing config reload tests to handle failure error return. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
When config reload command fails it would return a non zero error code. Without module_ignore_errors the ansible invoke command will crash.
Additional checks are introduced when checking for delayed services to ensure only enabled services are checked.

#### How did you do it?
Modify config reload tests to have module_ignore_errors  when config reload is expected to be failed.

#### How did you verify/test it?
Run the config reload tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
